### PR TITLE
updates to allow multiple rules for listener conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1406,10 +1406,12 @@ Or if you have an ALB already provisioned you can specify it like this:
 "alb_enabled": true,
 "alb_vpc_config": {
     "LoadBalancerArn": "arn:aws:acm:us-east-1:[your-account-id]:loadbalancer/app/[alb-name]/[f851177b4d4eb840]",
-    "alb_listener_rule_conditions": {
-        "Field": "path-pattern|host-header",
-        "Values": ["api/*"|"api.example.com"]
-    },
+    "alb_listener_rule_conditions": [
+        {
+            "Field": "path-pattern|host-header",
+            "Values": ["api/*"|"api.example.com"]
+        }
+    ],
     "alb_listener_rule_priority": 1
 }
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1978,10 +1978,10 @@ USE_TZ = True
             "lambda_name": "test",
             "alb_vpc_config": {
                 "LoadBalancerArn": str(uuid.uuid4()),
-                "alb_listener_rule_conditions": {
+                "alb_listener_rule_conditions": [{
                     "Field": "path-pattern",
                     "Values": ["api/*"]
-                }
+                }]
             },
             'timeout': '30',
         }
@@ -2002,10 +2002,10 @@ USE_TZ = True
             "lambda_name": str(uuid.uuid4()),
             "alb_vpc_config": {
                 "LoadBalancerArn": str(uuid.uuid4()),
-                "alb_listener_rule_conditions": {
+                "alb_listener_rule_conditions": [{
                     "Field": "path-pattern",
                     "Values": ["api/*"]
-                 },
+                 }],
                  "alb_listener_rule_priority": 1
             },
             "timeout": '30',
@@ -2113,7 +2113,7 @@ USE_TZ = True
                    "TargetGroupArn": targetgroup_arn
                }],
                "ListenerArn": listener_arn,
-               "Conditions": [ kwargs["alb_vpc_config"]["alb_listener_rule_conditions"] ],
+               "Conditions": kwargs["alb_vpc_config"]["alb_listener_rule_conditions"],
                "Priority" :  kwargs["alb_vpc_config"]["alb_listener_rule_priority"]
             },
             service_response={}
@@ -2444,8 +2444,6 @@ USE_TZ = True
         )
         lambda_stubber.activate()
         elbv2_stubber.activate()
-        #zappa_core.undeploy_lambda_alb(kwargs['lambda_name'])
-        #zappa_core.undeploy_lambda_alb(kwargs['lambda_name'], kwargs['alb_vpc_config'])
         zappa_core.undeploy_lambda_alb(**kwargs)
 
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1454,9 +1454,7 @@ class Zappa(object):
                     "TargetGroupArn": target_group_arn,
                 }],
                 ListenerArn=response["Listeners"][0]["ListenerArn"],
-                Conditions=[
-                   alb_vpc_config['alb_listener_rule_conditions']
-                ],
+                Conditions=alb_vpc_config['alb_listener_rule_conditions'],
                 Priority=alb_vpc_config['alb_listener_rule_priority']
             )
             response = self.elbv2_client.create_rule(**kwargs)


### PR DESCRIPTION
Adjust the config to allow multiple listener rule conditions

The  `alb_listener_rule_conditions` attribute is now a list, in line with the boto3 api
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_rule

This allows for a host and path-pattern combination, and it also supports the newly announced extra routing features: 
https://aws.amazon.com/blogs/aws/new-advanced-request-routing-for-aws-application-load-balancers/